### PR TITLE
Update comment to reflect state initialization sources

### DIFF
--- a/components/CanvasViewer.js
+++ b/components/CanvasViewer.js
@@ -19,7 +19,7 @@ export default function CanvasViewer() {
   const [redoHistory, setRedoHistory] = useState([]);
   const [textureList, setTextureList] = useState([]);
 
-  // Only initialize from IndexedDB, not localStorage
+  // Initialize state from localStorage and restore history from IndexedDB
   useEffect(() => {
     setModelUrl(localStorage.getItem('modelUrl') || null);
     setTextureList(JSON.parse(localStorage.getItem('textureList') || '[]'));


### PR DESCRIPTION
## Summary
- clarify how initial state is loaded in `CanvasViewer.js`

## Testing
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68404ece149c8326b9547abbc9953c99